### PR TITLE
Update README.md to the Correct BOM for ANT printers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ For V2.4, you'll need:
 
 ## BFI for Ants
 
-For Salad Fork and Micron, you'll need:
+For Salad Fork, you'll need:
 - 4× M3×25 BHCS
+- 4× standard Voron M3x5x4 heatset inserts (5mm outer diameter, 4mm deep)
+- 2× M3×12 SHCS
+
+For Micron, you'll need:
+- 4× M3×20 BHCS
 - 4× standard Voron M3x5x4 heatset inserts (5mm outer diameter, 4mm deep)
 - 2× M3×12 SHCS
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For V2.4, you'll need:
 ## BFI for Ants
 
 For Salad Fork and Micron, you'll need:
-- 4× M3×20 BHCS
+- 4× M3×25 BHCS
 - 4× standard Voron M3x5x4 heatset inserts (5mm outer diameter, 4mm deep)
 - 2× M3×12 SHCS
 


### PR DESCRIPTION
The CAD shows a 3x25mm for the ANT models of the idlers but the README says 3x20mm. This updates the BOM to match the latest CAD.